### PR TITLE
Allow the order of ActionItems in the pipeline to be modified

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0",
     "flexlayout-react": "^0.5.10",
-    "@mui/x-charts": "^7.0.0"
+    "@mui/x-charts": "^7.0.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,14 +104,12 @@ const App: React.FC = () => {
   }, [pipeline]);
 
   const moveAction = useCallback((draggedId: string, targetId: string) => {
-    const draggedIndex = actions.findIndex(action => action.id === draggedId);
+    const dragged = actions.find(action => action.id === draggedId);
     const targetIndex = actions.findIndex(action => action.id === targetId);
-    if (draggedIndex !== -1 && targetIndex !== -1) {
-      const updatedActions = [...actions];
-      const [draggedAction] = updatedActions.splice(draggedIndex, 1);
-      updatedActions.splice(targetIndex, 0, draggedAction);
-      setActions(updatedActions);
-      pipeline.moveAction(draggedAction as Action | CompositeAction, targetIndex);
+    if (dragged !== undefined && targetIndex !== -1) {
+      pipeline.moveAction(dragged as Action | CompositeAction, targetIndex);
+    } else {
+      console.log('failed to find dragged or target', draggedId, targetId)
     }
   }, [actions, pipeline]);
   

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,6 +102,18 @@ const App: React.FC = () => {
   const removeAction = useCallback((action: BaseAction) => {
     pipeline.removeAction(action);
   }, [pipeline]);
+
+  const moveAction = useCallback((draggedId: string, targetId: string) => {
+    const draggedIndex = actions.findIndex(action => action.id === draggedId);
+    const targetIndex = actions.findIndex(action => action.id === targetId);
+    if (draggedIndex !== -1 && targetIndex !== -1) {
+      const updatedActions = [...actions];
+      const [draggedAction] = updatedActions.splice(draggedIndex, 1);
+      updatedActions.splice(targetIndex, 0, draggedAction);
+      setActions(updatedActions);
+      pipeline.moveAction(draggedAction as Action | CompositeAction, targetIndex);
+    }
+  }, [actions, pipeline]);
   
   const handleEditSource = () => {
     setSelectedSource('')
@@ -221,7 +233,7 @@ const App: React.FC = () => {
       case 'pipeline': 
       return <PipelineViewer sourceName={sourceName} toggleActive={toggleActive} deleteAction={removeAction}
       groupAction={groupAction} actions={actions} unGroupAction={unGroupAction} outcomes={outcomes}   
-      visibleOutcomes={visibleOutcomes} setVisibleOutcomes={setVisibleOutcomes} onEditSource={handleEditSource} />
+      visibleOutcomes={visibleOutcomes} setVisibleOutcomes={setVisibleOutcomes} onEditSource={handleEditSource} moveAction={moveAction} />
       case 'detail':
       return <DetailView outcomes={outcomes} visibleOutcomes={visibleOutcomes} />
       case 'map':   

--- a/src/Pipeline.ts
+++ b/src/Pipeline.ts
@@ -111,7 +111,7 @@ class Pipeline {
     this.actionsListeners.forEach(listener => listener(this.actions));
   }
 
-  moveAction(action: BaseAction, newIndex: number) {
+  moveAction(action: Action | CompositeAction, newIndex: number) {
     const currentIndex = this.actions.findIndex(a => a === action);
     if (currentIndex === -1) {
       console.warn('Action not found in the pipeline', action);

--- a/src/Pipeline.ts
+++ b/src/Pipeline.ts
@@ -118,7 +118,7 @@ class Pipeline {
       return;
     }
     this.actions.splice(currentIndex, 1);
-    this.actions.splice(newIndex, 0, (action as Action | CompositeAction));
+    this.actions.splice(newIndex, 0, action);
     this.actionsListeners.forEach(listener => listener(this.actions));
   }
 }

--- a/src/Pipeline.ts
+++ b/src/Pipeline.ts
@@ -118,7 +118,7 @@ class Pipeline {
       return;
     }
     this.actions.splice(currentIndex, 1);
-    this.actions.splice(newIndex, 0, action);
+    this.actions.splice(newIndex, 0, (action as Action | CompositeAction));
     this.actionsListeners.forEach(listener => listener(this.actions));
   }
 }

--- a/src/Pipeline.ts
+++ b/src/Pipeline.ts
@@ -110,6 +110,17 @@ class Pipeline {
     // fire updates to action list listeners
     this.actionsListeners.forEach(listener => listener(this.actions));
   }
+
+  moveAction(action: BaseAction, newIndex: number) {
+    const currentIndex = this.actions.findIndex(a => a === action);
+    if (currentIndex === -1) {
+      console.warn('Action not found in the pipeline', action);
+      return;
+    }
+    this.actions.splice(currentIndex, 1);
+    this.actions.splice(newIndex, 0, action);
+    this.actionsListeners.forEach(listener => listener(this.actions));
+  }
 }
 
 export default Pipeline;

--- a/src/components/ActionItem.tsx
+++ b/src/components/ActionItem.tsx
@@ -21,6 +21,7 @@ import { BaseAction, CompositeAction } from '../Pipeline';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { useDrag, useDrop } from 'react-dnd';
+import DragHandleIcon from '@mui/icons-material/DragHandle';
 
 interface ActionItemProps {
   action: BaseAction;
@@ -197,6 +198,7 @@ const ActionItem: React.FC<ActionItemProps> = ({ action, child, toggleActive, de
             </IconButton>
           </Tooltip>
         )}
+        <DragHandleIcon />
         { action.active ? <CheckIcon onClick={(e) => { e.stopPropagation(); toggleActive(action); }} />: <CheckBoxOutlineBlankIcon onClick={(e) => { e.stopPropagation(); toggleActive(action); }} />}
         <DeleteIcon onClick={(e) => { e.stopPropagation(); deleteAction(action); }}  />
       </CardActions>

--- a/src/components/ActionItem.tsx
+++ b/src/components/ActionItem.tsx
@@ -20,6 +20,7 @@ import './ActionItem.css';
 import { BaseAction, CompositeAction } from '../Pipeline';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import { useDrag, useDrop } from 'react-dnd';
 
 interface ActionItemProps {
   action: BaseAction;
@@ -30,7 +31,8 @@ interface ActionItemProps {
   child?: boolean;
   outcomes: Outcomes;
   visibleOutcomes: ShadedOutcome[];
-  toggleVisibleOutcome: (id: string) => void
+  toggleVisibleOutcome: (id: string) => void;
+  moveAction: (draggedId: string, targetId: string) => void;
 }
 
 const iconFor = (action: BaseAction): React.ReactElement => {
@@ -81,7 +83,7 @@ const ExpandMore = styled((props: ExpandMoreProps) => {
   ],
 }));
 
-const ActionItem: React.FC<ActionItemProps> = ({ action, child, toggleActive, deleteAction, selected, setSelected, outcomes, visibleOutcomes, toggleVisibleOutcome }) => {
+const ActionItem: React.FC<ActionItemProps> = ({ action, child, toggleActive, deleteAction, selected, setSelected, outcomes, visibleOutcomes, toggleVisibleOutcome, moveAction }) => {
 
   const [expanded, setExpanded] = React.useState(false);
   const [color, setColor] = React.useState<string | null>(null);
@@ -135,15 +137,35 @@ const ActionItem: React.FC<ActionItemProps> = ({ action, child, toggleActive, de
     toggleVisibleOutcome(action.id);
   };
 
+  const [{ isDragging }, dragRef] = useDrag({
+    type: 'ACTION_ITEM',
+    item: { id: action.id },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+    canDrag: () => !child, // Prevent dragging if it's a child action
+  });
+
+  const [, dropRef] = useDrop({
+    accept: 'ACTION_ITEM',
+    hover: (draggedItem: { id: string }) => {
+      if (draggedItem.id !== action.id) {
+        moveAction(draggedItem.id, action.id);
+      }
+    },
+  });
+
   return (
     <Card
+      ref={(node) => dragRef(dropRef(node))}
       variant='outlined'
       style={{
         margin: '5px',
         borderWidth: selected ? '2px' : '1px',
         backgroundColor: selected ? '#d3d3d3' : 'white',
         marginLeft: child ? '20px' : '0px',
-        width: '90%'
+        width: '90%',
+        opacity: isDragging ? 0.5 : 1,
       }}
       className="action-item"
       onClick={handleSelection}
@@ -179,7 +201,7 @@ const ActionItem: React.FC<ActionItemProps> = ({ action, child, toggleActive, de
         <DeleteIcon onClick={(e) => { e.stopPropagation(); deleteAction(action); }}  />
       </CardActions>
       {expanded && (action as CompositeAction).items.map((item) => {
-        return <ActionItem child key={item.id} action={item} toggleActive={toggleActive} deleteAction={deleteAction} outcomes={outcomes} selected={selected} toggleVisibleOutcome={toggleVisibleOutcome} setSelected={setSelected} visibleOutcomes={visibleOutcomes}  />
+        return <ActionItem child key={item.id} action={item} toggleActive={toggleActive} deleteAction={deleteAction} outcomes={outcomes} selected={selected} toggleVisibleOutcome={toggleVisibleOutcome} setSelected={setSelected} visibleOutcomes={visibleOutcomes} moveAction={moveAction} />
       })}
     </Card>
   );

--- a/src/components/ActionItem.tsx
+++ b/src/components/ActionItem.tsx
@@ -149,11 +149,11 @@ const ActionItem: React.FC<ActionItemProps> = ({ action, child, toggleActive, de
 
   const [, dropRef] = useDrop({
     accept: 'ACTION_ITEM',
-    hover: (draggedItem: { id: string }) => {
+    drop(draggedItem: { id: string }) {
       if (draggedItem.id !== action.id) {
         moveAction(draggedItem.id, action.id);
       }
-    },
+    }
   });
 
   return (

--- a/src/components/PipelineViewer.tsx
+++ b/src/components/PipelineViewer.tsx
@@ -11,7 +11,7 @@ import CallMergeIcon from '@mui/icons-material/CallMerge';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import { BaseAction } from '../Pipeline';
-import { DndProvider } from 'react-dnd';
+import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
 type PipelineProps = {

--- a/src/components/PipelineViewer.tsx
+++ b/src/components/PipelineViewer.tsx
@@ -11,7 +11,7 @@ import CallMergeIcon from '@mui/icons-material/CallMerge';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import { BaseAction } from '../Pipeline';
-import { DndProvider, useDrag, useDrop } from 'react-dnd';
+import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
 type PipelineProps = {

--- a/src/components/PipelineViewer.tsx
+++ b/src/components/PipelineViewer.tsx
@@ -25,6 +25,7 @@ type PipelineProps = {
   outcomes: Outcomes;
   visibleOutcomes: ShadedOutcome[];
   setVisibleOutcomes: (visibleOutcomeIds: ShadedOutcome[]) => void;
+  moveAction: (draggedId: string, targetId: string) => void;
 }
 
 type DialogProps = {
@@ -36,7 +37,7 @@ type DialogProps = {
 
 const PipelineViewer: React.FC<PipelineProps> = ({ actions, toggleActive, deleteAction, 
   groupAction, unGroupAction, outcomes, visibleOutcomes, setVisibleOutcomes, sourceName,
-  onEditSource
+  onEditSource, moveAction
  }) => {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [showDialog, setShowDialog] = useState<DialogProps | null>(null);
@@ -243,21 +244,6 @@ const PipelineViewer: React.FC<PipelineProps> = ({ actions, toggleActive, delete
   const VerticalSeprator = (): React.ReactElement => {
     return <div className='vertical-separator'></div>
   }
-
-  const moveAction = (draggedId: string, targetId: string) => {
-    const draggedIndex = actions.findIndex(action => action.id === draggedId);
-    const targetIndex = actions.findIndex(action => action.id === targetId);
-    if (draggedIndex !== -1 && targetIndex !== -1) {
-      const updatedActions = [...actions];
-      const [draggedAction] = updatedActions.splice(draggedIndex, 1);
-      updatedActions.splice(targetIndex, 0, draggedAction);
-      // Update the actions state with the new order
-      // This will trigger a re-render of the component
-      // and the new order will be reflected in the UI
-      // Note: This is a simplified example, you may need to update the state in your parent component
-      // and pass the updated actions as props to this component
-    }
-  };
 
   return (
     <DndProvider backend={HTML5Backend}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,7 +1062,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.25.9"
     "@babel/plugin-transform-typescript" "^7.25.9"
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.26.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.9", "@babel/runtime@^7.25.7", "@babel/runtime@^7.26.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
@@ -1353,33 +1353,6 @@
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
-
-"@floating-ui/core@^1.6.0":
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.8.tgz#aa43561be075815879305965020f492cdb43da12"
-  integrity sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==
-  dependencies:
-    "@floating-ui/utils" "^0.2.8"
-
-"@floating-ui/dom@^1.0.0":
-  version "1.6.12"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.12.tgz#6333dcb5a8ead3b2bf82f33d6bc410e95f54e556"
-  integrity sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==
-  dependencies:
-    "@floating-ui/core" "^1.6.0"
-    "@floating-ui/utils" "^0.2.8"
-
-"@floating-ui/react-dom@^2.1.1":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
-  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
-  dependencies:
-    "@floating-ui/dom" "^1.0.0"
-
-"@floating-ui/utils@^0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
-  integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
@@ -1709,19 +1682,6 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
   integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
 
-"@mui/base@^5.0.0-beta.22":
-  version "5.0.0-beta.61"
-  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.61.tgz#729e816b5104da1eeeacb11d1e61be90f2c21dcc"
-  integrity sha512-YaMOTXS3ecDNGsPKa6UdlJ8loFLvcL9+VbpCK3hfk71OaNauZRp4Yf7KeXDYr7Ms3M/XBD3SaiR6JMr6vYtfDg==
-  dependencies:
-    "@babel/runtime" "^7.26.0"
-    "@floating-ui/react-dom" "^2.1.1"
-    "@mui/types" "^7.2.19"
-    "@mui/utils" "^6.1.6"
-    "@popperjs/core" "^2.11.8"
-    clsx "^2.1.1"
-    prop-types "^15.8.1"
-
 "@mui/core-downloads-tracker@^5.16.7":
   version "5.16.7"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.7.tgz#182a325a520f7ebd75de051fceabfc0314cfd004"
@@ -1802,7 +1762,7 @@
     prop-types "^15.8.1"
     react-is "^18.3.1"
 
-"@mui/utils@^6.1.6":
+"@mui/utils@^5.16.6 || ^6.0.0":
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.1.6.tgz#4b9fd34da3a1dd4700fe506a20ca7da3933ba48e"
   integrity sha512-sBS6D9mJECtELASLM+18WUcXF6RH3zNxBRFeyCRg8wad6NbyNrdxLuwK+Ikvc38sTZwBzAz691HmSofLqHd9sQ==
@@ -1814,20 +1774,48 @@
     prop-types "^15.8.1"
     react-is "^18.3.1"
 
-"@mui/x-charts@^5.17.2":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@mui/x-charts/-/x-charts-6.18.1.tgz#35ae2a7f6a829407534fd5faecbcb3be4c3ff45e"
-  integrity sha512-JF0BVkEjZgQMKqGW9Lzcfwlbml5OqlAEOlSDGKConwRdgTZNYXreakGrKVEemaO4bmqLmsFduKowkRV4Ng7Bfw==
+"@mui/x-charts-vendor@7.20.0":
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-charts-vendor/-/x-charts-vendor-7.20.0.tgz#b5858b91da0bde4f9c31f5360d05ade0b6eb5e31"
+  integrity sha512-pzlh7z/7KKs5o0Kk0oPcB+sY0+Dg7Q7RzqQowDQjpy5Slz6qqGsgOB5YUzn0L+2yRmvASc4Pe0914Ao3tMBogg==
   dependencies:
-    "@babel/runtime" "^7.23.2"
-    "@mui/base" "^5.0.0-beta.22"
-    "@react-spring/rafz" "^9.7.3"
-    "@react-spring/web" "^9.7.3"
-    clsx "^2.0.0"
+    "@babel/runtime" "^7.25.7"
+    "@types/d3-color" "^3.1.3"
+    "@types/d3-delaunay" "^6.0.4"
+    "@types/d3-interpolate" "^3.0.4"
+    "@types/d3-scale" "^4.0.8"
+    "@types/d3-shape" "^3.1.6"
+    "@types/d3-time" "^3.0.3"
     d3-color "^3.1.0"
+    d3-delaunay "^6.0.4"
+    d3-interpolate "^3.0.1"
     d3-scale "^4.0.2"
     d3-shape "^3.2.0"
+    d3-time "^3.1.0"
+    delaunator "^5.0.1"
+    robust-predicates "^3.0.2"
+
+"@mui/x-charts@^7.0.0":
+  version "7.22.2"
+  resolved "https://registry.yarnpkg.com/@mui/x-charts/-/x-charts-7.22.2.tgz#9768629d1b5bf949cd4f86da8e1c423dfbf36729"
+  integrity sha512-0Y2du4Ed7gOT53l8vVJ4vKT+Jz4Dh/iHnLy8TtL3+XhbPH9Ndu9Q30WwyyzOn84yt37hSUru/njQ1BWaSvVPHw==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0"
+    "@mui/x-charts-vendor" "7.20.0"
+    "@mui/x-internals" "7.21.0"
+    "@react-spring/rafz" "^9.7.5"
+    "@react-spring/web" "^9.7.5"
+    clsx "^2.1.1"
     prop-types "^15.8.1"
+
+"@mui/x-internals@7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-7.21.0.tgz#daca984059015b27efdb47bb44dc7ff4a6816673"
+  integrity sha512-94YNyZ0BhK5Z+Tkr90RKf47IVCW8R/1MvdUhh6MCQg6sZa74jsX+x+gEZ4kzuCqOsuyTyxikeQ8vVuCIQiP7UQ==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0"
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -1880,6 +1868,21 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
+"@react-dnd/asap@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
+  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
+
+"@react-dnd/invariant@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-4.0.2.tgz#b92edffca10a26466643349fac7cdfb8799769df"
+  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
+
+"@react-dnd/shallowequal@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
+  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
+
 "@react-leaflet/core@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-2.1.0.tgz#383acd31259d7c9ae8fb1b02d5e18fe613c2a13d"
@@ -1902,7 +1905,7 @@
     "@react-spring/shared" "~9.7.5"
     "@react-spring/types" "~9.7.5"
 
-"@react-spring/rafz@^9.7.3", "@react-spring/rafz@~9.7.5":
+"@react-spring/rafz@^9.7.5", "@react-spring/rafz@~9.7.5":
   version "9.7.5"
   resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.7.5.tgz#ee7959676e7b5d6a3813e8c17d5e50df98b95df9"
   integrity sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==
@@ -1920,7 +1923,7 @@
   resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.7.5.tgz#e5dd180f3ed985b44fd2cd2f32aa9203752ef3e8"
   integrity sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==
 
-"@react-spring/web@^9.7.3":
+"@react-spring/web@^9.7.5":
   version "9.7.5"
   resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.7.5.tgz#7d7782560b3a6fb9066b52824690da738605de80"
   integrity sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==
@@ -3400,6 +3403,47 @@
   dependencies:
     "@types/node" "*"
 
+"@types/d3-color@*", "@types/d3-color@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-delaunay@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
+  integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
+
+"@types/d3-interpolate@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.0.tgz#2b907adce762a78e98828f0b438eaca339ae410a"
+  integrity sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==
+
+"@types/d3-scale@^4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.8.tgz#d409b5f9dcf63074464bf8ddfb8ee5a1f95945bb"
+  integrity sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-shape@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.6.tgz#65d40d5a548f0a023821773e39012805e6e31a72"
+  integrity sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time@*", "@types/d3-time@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.3.tgz#3c186bbd9d12b9d84253b6be6487ca56b54f88be"
+  integrity sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==
+
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -4723,7 +4767,7 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-clsx@^2.0.0, clsx@^2.1.0, clsx@^2.1.1:
+clsx@^2.1.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -5165,6 +5209,13 @@ d3-array@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
+d3-delaunay@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+  dependencies:
+    delaunator "5"
+
 "d3-format@1 - 3":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
@@ -5177,7 +5228,7 @@ d3-geo@1.7.1:
   dependencies:
     d3-array "1"
 
-"d3-interpolate@1.2.0 - 3":
+"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
@@ -5214,7 +5265,7 @@ d3-shape@^3.2.0:
   dependencies:
     d3-time "1 - 3"
 
-"d3-time@1 - 3", "d3-time@2.1.1 - 3":
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
@@ -5374,6 +5425,13 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+delaunator@5, delaunator@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.1.tgz#39032b08053923e924d6094fe2cde1a99cc51278"
+  integrity sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==
+  dependencies:
+    robust-predicates "^3.0.2"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -5443,6 +5501,15 @@ dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
+dnd-core@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-16.0.1.tgz#a1c213ed08961f6bd1959a28bb76f1a868360d19"
+  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
+  dependencies:
+    "@react-dnd/asap" "^5.0.1"
+    "@react-dnd/invariant" "^4.0.1"
+    redux "^4.2.0"
 
 dns-packet@^5.2.2:
   version "5.6.1"
@@ -6722,7 +6789,7 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -9580,6 +9647,24 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
+react-dnd-html5-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
+  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+  dependencies:
+    dnd-core "^16.0.1"
+
+react-dnd@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
+  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
+  dependencies:
+    "@react-dnd/invariant" "^4.0.1"
+    "@react-dnd/shallowequal" "^4.0.1"
+    dnd-core "^16.0.1"
+    fast-deep-equal "^3.1.3"
+    hoist-non-react-statics "^3.3.2"
+
 react-dom@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
@@ -9742,6 +9827,13 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
Fixes #58

Add functionality to modify the order of ActionItems in the pipeline by dragging them up and down.

* **Pipeline Class (`src/Pipeline.ts`)**
  - Add `moveAction` method to move an action to a different index in the sequence.

* **ActionItem Component (`src/components/ActionItem.tsx`)**
  - Add a drag handle for dragging actions up and down.
  - Implement drag and drop functionality using the `react-dnd` library.
  - Prevent child actions from being dragged out of an expanded CompositeAction.

* **PipelineViewer Component (`src/components/PipelineViewer.tsx`)**
  - Add the drag and drop context provider using `DndProvider` and `HTML5Backend`.
  - Update the component to handle the reordering of actions by dragging.
  - Add `moveAction` method to update the order of actions in the state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/debrief/rap-lines/pull/59?shareId=f5709df0-6523-4daa-b03e-49726738fc4a).